### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+BooksCompare is a pnpm monorepo with three packages. See `CLAUDE.md` and `README.md` for full command reference. Key commands: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm test:mobile`, `pnpm dev:api`.
+
+### Services
+
+| Service                 | Command           | Port | Notes                                                                                  |
+| ----------------------- | ----------------- | ---- | -------------------------------------------------------------------------------------- |
+| API (Cloudflare Worker) | `pnpm dev:api`    | 8787 | Stateless; no DB or external secrets needed locally. Wrangler simulates rate-limiting. |
+| Mobile (Expo)           | `pnpm dev:mobile` | 8081 | Requires iOS Simulator or physical device; not runnable headlessly in Cloud Agent VMs. |
+
+### Gotchas
+
+- **`pnpm install` exits non-zero** on first run because the `prepare` script runs `lefthook install`, which conflicts with the Cursor agent hooks path (`core.hooksPath`). Dependencies are still installed correctly. Use `pnpm install --ignore-scripts` if a clean exit code is needed, then run build-related postinstall scripts separately if required (e.g. `npx esbuild --version` or `npx wrangler --version` to trigger lazy native installs).
+- **Mobile app cannot be tested in Cloud Agent VMs** — there is no iOS Simulator or Android emulator. The mobile Jest tests (`pnpm test:mobile`) run fine headlessly.
+- **`apps/mobile/.env`** must exist before running mobile commands. Copy from `.env.example`: `cp apps/mobile/.env.example apps/mobile/.env`.
+- **Node.js >=20 and pnpm 9.15.0** are required (see `.nvmrc` and `packageManager` field in root `package.json`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions covering:

- Service overview (API on port 8787, Mobile on port 8081)
- Known gotchas: `pnpm install` non-zero exit from lefthook hooks conflict, mobile app not testable in headless VMs, `.env` file requirement
- Node.js/pnpm version requirements

### Verified

All checks pass in the Cloud Agent environment:

- `pnpm typecheck` — all 3 workspace packages pass
- `pnpm lint` — clean
- `pnpm format:check` — clean
- `pnpm test` — 40/40 API tests pass
- `pnpm test:mobile` — 7/7 test suites, 10/10 tests pass
- `pnpm dev:api` — Wrangler dev server starts on port 8787
- API endpoints (`/`, `/health`, `/search?q=哈利波特`) return correct responses

API demo output:
[api_demo.log](https://cursor.com/agents/bc-d578f47c-beac-42f0-a86e-30675520fa30/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d578f47c-beac-42f0-a86e-30675520fa30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d578f47c-beac-42f0-a86e-30675520fa30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

