### PR TITLE
feat(mobile): add bookstore preference settings

### DIFF
--- a/apps/mobile/src/i18n/dictionaries.ts
+++ b/apps/mobile/src/i18n/dictionaries.ts
@@ -108,6 +108,13 @@ interface Dictionary {
     appearanceDark: string;
     cancelAction: string;
   };
+  storePreferences: {
+    title: string;
+    settingsRow: string;
+    settingsRowValue: (count: number) => string;
+    settingsRowValueAll: string;
+    description: string;
+  };
   webview: {
     shareAccessibility: string;
     loadingLabel: string;
@@ -238,6 +245,13 @@ const zhTW: Dictionary = {
     appearanceLight: '淺色',
     appearanceDark: '深色',
     cancelAction: '取消',
+  },
+  storePreferences: {
+    title: '書店偏好',
+    settingsRow: '書店偏好',
+    settingsRowValue: (count) => `已選 ${count} 家`,
+    settingsRowValueAll: '全部',
+    description: '選擇您想要比較的書店。未選擇任何書店時，將顯示所有書店的結果。',
   },
   webview: {
     shareAccessibility: '分享',
@@ -372,6 +386,14 @@ const en: Dictionary = {
     appearanceLight: 'Light',
     appearanceDark: 'Dark',
     cancelAction: 'Cancel',
+  },
+  storePreferences: {
+    title: 'Bookstore Preferences',
+    settingsRow: 'Bookstores',
+    settingsRowValue: (count) => `${count} selected`,
+    settingsRowValueAll: 'All',
+    description:
+      'Choose which bookstores to compare. When none are selected, results from all stores are shown.',
   },
   webview: {
     shareAccessibility: 'Share',

--- a/apps/mobile/src/lib/preferences.ts
+++ b/apps/mobile/src/lib/preferences.ts
@@ -1,6 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useEffect, useState } from 'react';
 
+import { BOOK_SOURCES } from '@bookscompare/contracts';
+
+import type { BookSourceId } from '@bookscompare/contracts';
+
 export const PREFERENCES_STORAGE_KEY = 'bookscompare:preferences:v1';
 
 export type OpenLinksIn = 'app' | 'browser';
@@ -9,13 +13,17 @@ export type ThemeMode = 'system' | 'light' | 'dark';
 export interface Preferences {
   openLinksIn: OpenLinksIn;
   themeMode: ThemeMode;
+  preferredSources: BookSourceId[];
 }
 
 type PreferenceKey = keyof Preferences;
 
+const validSourceIds = new Set<string>(BOOK_SOURCES.map((s) => s.id));
+
 const defaultPreferences: Preferences = {
   openLinksIn: 'app',
   themeMode: 'system',
+  preferredSources: [],
 };
 
 const validators: {
@@ -24,6 +32,8 @@ const validators: {
   openLinksIn: (value): value is OpenLinksIn => value === 'app' || value === 'browser',
   themeMode: (value): value is ThemeMode =>
     value === 'system' || value === 'light' || value === 'dark',
+  preferredSources: (value): value is BookSourceId[] =>
+    Array.isArray(value) && value.every((v) => typeof v === 'string' && validSourceIds.has(v)),
 };
 
 let currentPreferences = defaultPreferences;

--- a/apps/mobile/src/navigation/AboutStack.tsx
+++ b/apps/mobile/src/navigation/AboutStack.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { AboutScreen } from '../screens/about/AboutScreen';
 import { SettingsScreen } from '../screens/about/SettingsScreen';
+import { StorePreferencesScreen } from '../screens/about/StorePreferencesScreen';
 import { WebViewScreen } from '../screens/common/WebViewScreen';
 import { strings } from '../i18n/strings';
 import { useTheme } from '../theme/ThemeProvider';
@@ -37,6 +38,11 @@ export function AboutStack() {
         name="Settings"
         component={SettingsScreen}
         options={{ title: strings.navigation.settings }}
+      />
+      <Stack.Screen
+        name="StorePreferences"
+        component={StorePreferencesScreen}
+        options={{ title: strings.storePreferences.title }}
       />
       <Stack.Screen name="AboutWebView" component={WebViewScreen} />
     </Stack.Navigator>

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -24,6 +24,7 @@ export type FavouritesStackParamList = SearchResultRoutes & {
 export type AboutStackParamList = {
   About: undefined;
   Settings: undefined;
+  StorePreferences: undefined;
   AboutWebView: WebViewScreenParams;
 };
 

--- a/apps/mobile/src/screens/about/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/about/AboutScreen.test.tsx
@@ -14,6 +14,7 @@ const mockUpdatePreference = jest.fn();
 const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   openLinksIn: 'app',
   themeMode: 'system',
+  preferredSources: [],
 }));
 
 jest.mock('../../lib/preferences', () => ({
@@ -25,7 +26,11 @@ describe('AboutScreen', () => {
   beforeEach(() => {
     jest.mocked(openExternalUrl).mockReset();
     mockUpdatePreference.mockReset();
-    mockGetPreferences.mockReturnValue({ openLinksIn: 'app', themeMode: 'system' });
+    mockGetPreferences.mockReturnValue({
+      openLinksIn: 'app',
+      themeMode: 'system',
+      preferredSources: [],
+    });
   });
 
   it('opens in-app links in the webview screen when preference is app', () => {
@@ -49,7 +54,11 @@ describe('AboutScreen', () => {
   });
 
   it('opens links externally when preference is browser', () => {
-    mockGetPreferences.mockReturnValue({ openLinksIn: 'browser', themeMode: 'system' });
+    mockGetPreferences.mockReturnValue({
+      openLinksIn: 'browser',
+      themeMode: 'system',
+      preferredSources: [],
+    });
 
     const navigation = {
       navigate: jest.fn(),

--- a/apps/mobile/src/screens/about/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.test.tsx
@@ -15,6 +15,7 @@ const mockUpdatePreference = jest.fn();
 const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   openLinksIn: 'app',
   themeMode: 'system',
+  preferredSources: [],
 }));
 
 jest.mock('@expo/react-native-action-sheet', () => {
@@ -37,7 +38,11 @@ describe('SettingsScreen', () => {
     jest.mocked(track).mockReset();
     mockUpdatePreference.mockReset();
     mockShowActionSheetWithOptions.mockReset();
-    mockGetPreferences.mockReturnValue({ openLinksIn: 'app', themeMode: 'system' });
+    mockGetPreferences.mockReturnValue({
+      openLinksIn: 'app',
+      themeMode: 'system',
+      preferredSources: [],
+    });
   });
 
   it('renders current preferences', () => {

--- a/apps/mobile/src/screens/about/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.tsx
@@ -58,7 +58,7 @@ function SettingsRow({ icon, iconBackground, title, value, onPress }: SettingsRo
   );
 }
 
-export function SettingsScreen(_props: Props) {
+export function SettingsScreen({ navigation }: Props) {
   const { colors } = useTheme();
   const { showActionSheetWithOptions } = useActionSheet();
   const preferences = usePreferences();
@@ -103,6 +103,11 @@ export function SettingsScreen(_props: Props) {
     });
   };
 
+  const storePrefsValue =
+    preferences.preferredSources.length === 0
+      ? strings.storePreferences.settingsRowValueAll
+      : strings.storePreferences.settingsRowValue(preferences.preferredSources.length);
+
   return (
     <ScrollView
       style={styles.container}
@@ -133,6 +138,19 @@ export function SettingsScreen(_props: Props) {
           title={strings.settings.appearance}
           value={themeModeLabel(preferences.themeMode)}
           onPress={showThemeModePicker}
+        />
+      </View>
+
+      <Text style={[styles.sectionHeader, styles.sectionHeaderSpaced]}>
+        {strings.storePreferences.title}
+      </Text>
+      <View style={styles.group}>
+        <SettingsRow
+          icon="storefront-outline"
+          iconBackground={colors.success}
+          title={strings.storePreferences.settingsRow}
+          value={storePrefsValue}
+          onPress={() => navigation.navigate('StorePreferences')}
         />
       </View>
     </ScrollView>

--- a/apps/mobile/src/screens/about/StorePreferencesScreen.test.tsx
+++ b/apps/mobile/src/screens/about/StorePreferencesScreen.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent } from '@testing-library/react-native';
+
+import { StorePreferencesScreen } from './StorePreferencesScreen';
+import { track } from '../../analytics';
+import { renderWithProviders } from '../../test/test-utils';
+
+import type { Preferences } from '../../lib/preferences';
+
+jest.mock('../../analytics', () => ({
+  track: jest.fn(),
+}));
+
+const mockUpdatePreference = jest.fn();
+const mockGetPreferences = jest.fn<Preferences, []>(() => ({
+  openLinksIn: 'app',
+  themeMode: 'system',
+  preferredSources: [],
+}));
+
+jest.mock('../../lib/preferences', () => ({
+  usePreferences: () => mockGetPreferences(),
+  updatePreference: (...args: unknown[]) => mockUpdatePreference(...args),
+}));
+
+describe('StorePreferencesScreen', () => {
+  beforeEach(() => {
+    jest.mocked(track).mockReset();
+    mockUpdatePreference.mockReset();
+    mockGetPreferences.mockReturnValue({
+      openLinksIn: 'app',
+      themeMode: 'system',
+      preferredSources: [],
+    });
+  });
+
+  it('renders all bookstore toggles', () => {
+    const screen = renderWithProviders(
+      <StorePreferencesScreen
+        navigation={{} as never}
+        route={{ key: 'StorePreferences', name: 'StorePreferences' } as never}
+      />
+    );
+
+    expect(screen.getByText('博客來')).toBeOnTheScreen();
+    expect(screen.getByText('金石堂')).toBeOnTheScreen();
+    expect(screen.getByText('城邦讀書花園')).toBeOnTheScreen();
+    expect(screen.getByText('誠品線上')).toBeOnTheScreen();
+  });
+
+  it('toggles are off when no preferred sources are set', () => {
+    const screen = renderWithProviders(
+      <StorePreferencesScreen
+        navigation={{} as never}
+        route={{ key: 'StorePreferences', name: 'StorePreferences' } as never}
+      />
+    );
+
+    const toggle = screen.getByTestId('store-toggle-books-com-tw');
+    expect(toggle.props.value).toBe(false);
+  });
+
+  it('toggles on a store and persists the preference', () => {
+    const screen = renderWithProviders(
+      <StorePreferencesScreen
+        navigation={{} as never}
+        route={{ key: 'StorePreferences', name: 'StorePreferences' } as never}
+      />
+    );
+
+    fireEvent(screen.getByTestId('store-toggle-books-com-tw'), 'valueChange', true);
+
+    expect(mockUpdatePreference).toHaveBeenCalledWith('preferredSources', ['books-com-tw']);
+    expect(track).toHaveBeenCalledWith('settings_change', {
+      key: 'preferredSources',
+      value: 'books-com-tw',
+    });
+  });
+
+  it('toggles off a store that was previously selected', () => {
+    mockGetPreferences.mockReturnValue({
+      openLinksIn: 'app',
+      themeMode: 'system',
+      preferredSources: ['books-com-tw', 'eslite'],
+    });
+
+    const screen = renderWithProviders(
+      <StorePreferencesScreen
+        navigation={{} as never}
+        route={{ key: 'StorePreferences', name: 'StorePreferences' } as never}
+      />
+    );
+
+    fireEvent(screen.getByTestId('store-toggle-books-com-tw'), 'valueChange', false);
+
+    expect(mockUpdatePreference).toHaveBeenCalledWith('preferredSources', ['eslite']);
+  });
+
+  it('reflects currently selected stores as toggled on', () => {
+    mockGetPreferences.mockReturnValue({
+      openLinksIn: 'app',
+      themeMode: 'system',
+      preferredSources: ['kingstone'],
+    });
+
+    const screen = renderWithProviders(
+      <StorePreferencesScreen
+        navigation={{} as never}
+        route={{ key: 'StorePreferences', name: 'StorePreferences' } as never}
+      />
+    );
+
+    expect(screen.getByTestId('store-toggle-kingstone').props.value).toBe(true);
+    expect(screen.getByTestId('store-toggle-books-com-tw').props.value).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/about/StorePreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/StorePreferencesScreen.tsx
@@ -1,0 +1,111 @@
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { useMemo } from 'react';
+import { ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
+
+import { BOOK_SOURCES } from '@bookscompare/contracts';
+
+import { track } from '../../analytics';
+import { strings } from '../../i18n/strings';
+import { updatePreference, usePreferences } from '../../lib/preferences';
+import { spacing } from '../../theme/spacing';
+import { useTheme } from '../../theme/ThemeProvider';
+import { typography } from '../../theme/typography';
+
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { BookSourceId } from '@bookscompare/contracts';
+import type { ThemeColors } from '../../theme/colors';
+import type { AboutStackParamList } from '../../navigation/types';
+
+type Props = NativeStackScreenProps<AboutStackParamList, 'StorePreferences'>;
+
+export function StorePreferencesScreen(_props: Props) {
+  const { colors } = useTheme();
+  const { preferredSources } = usePreferences();
+  const tabBarHeight = useBottomTabBarHeight();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const preferredSet = useMemo(() => new Set(preferredSources), [preferredSources]);
+
+  const toggleSource = (sourceId: BookSourceId) => {
+    const next = preferredSet.has(sourceId)
+      ? preferredSources.filter((id) => id !== sourceId)
+      : [...preferredSources, sourceId];
+
+    track('settings_change', { key: 'preferredSources', value: next.join(',') });
+    void updatePreference('preferredSources', next);
+  };
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={[
+        styles.contentContainer,
+        { paddingBottom: tabBarHeight + spacing.xl },
+      ]}
+      contentInsetAdjustmentBehavior="automatic"
+    >
+      <Text style={styles.description}>{strings.storePreferences.description}</Text>
+      <View style={styles.group}>
+        {BOOK_SOURCES.map((source, index) => {
+          const isLast = index === BOOK_SOURCES.length - 1;
+          return (
+            <View key={source.id} style={styles.row}>
+              <View style={[styles.rowContent, !isLast && styles.rowDivider]}>
+                <Text style={styles.label}>{source.name}</Text>
+                <Switch
+                  testID={`store-toggle-${source.id}`}
+                  value={preferredSet.has(source.id)}
+                  onValueChange={() => toggleSource(source.id)}
+                  trackColor={{ true: colors.accent, false: undefined }}
+                />
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+}
+
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.groupedBackground,
+    },
+    contentContainer: {
+      paddingTop: spacing.md,
+    },
+    description: {
+      ...typography.footnote,
+      color: colors.inkMuted,
+      paddingHorizontal: spacing.md + spacing.xs,
+      paddingBottom: spacing.sm,
+    },
+    group: {
+      marginHorizontal: spacing.md,
+      backgroundColor: colors.surface,
+      borderRadius: 14,
+      overflow: 'hidden',
+    },
+    row: {
+      paddingLeft: spacing.md,
+      backgroundColor: colors.surface,
+    },
+    rowContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingVertical: spacing.sm - 2,
+      paddingRight: spacing.md,
+    },
+    rowDivider: {
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.divider,
+    },
+    label: {
+      ...typography.body,
+      color: colors.ink,
+      flexShrink: 1,
+    },
+  });

--- a/apps/mobile/src/screens/home/SearchResultScreen.tsx
+++ b/apps/mobile/src/screens/home/SearchResultScreen.tsx
@@ -37,7 +37,7 @@ export function SearchResultScreen({ navigation, route }: Props) {
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const tabBarHeight = useBottomTabBarHeight();
-  const { openLinksIn } = usePreferences();
+  const { openLinksIn, preferredSources } = usePreferences();
   const isbnParam = 'isbn' in route.params ? route.params.isbn : '';
   const titleParam = 'title' in route.params ? route.params.title : '';
   const isbnQuery = useIsbnLookup(isbnParam);
@@ -47,17 +47,23 @@ export function SearchResultScreen({ navigation, route }: Props) {
   const isLoading = isbnParam ? isbnQuery.isLoading : titleQuery.isLoading;
   const isRefetching = isbnParam ? isbnQuery.isRefetching : titleQuery.isRefetching;
   const refetch = isbnParam ? isbnQuery.refetch : titleQuery.refetch;
+  const preferredSet = useMemo(() => new Set(preferredSources), [preferredSources]);
   const offers = useMemo(() => {
+    let items: BookOffer[];
     if (!data) {
-      return [];
+      items = [];
+    } else if ('book' in data) {
+      items = data.book ? data.book.offers : [];
+    } else {
+      items = data.books.flatMap((book) => book.offers);
     }
 
-    if ('book' in data) {
-      return data.book ? data.book.offers : [];
+    if (preferredSet.size === 0) {
+      return items;
     }
 
-    return data.books.flatMap((book) => book.offers);
-  }, [data]);
+    return items.filter((offer) => preferredSet.has(offer.sourceId));
+  }, [data, preferredSet]);
   const sources = data?.sources ?? [];
   const liveScraping = data?.meta.liveScraping ?? false;
   const resultCount = offers.length;


### PR DESCRIPTION
## Summary
- Add a bookstore preferences feature that lets users select which Taiwan bookstores to include in search results and book detail screens.
- Preferences are persisted locally via AsyncStorage and applied as client-side filtering — no API changes needed.
- Default behavior (no stores selected) shows all results, preserving backward compatibility.

## Changes
- Add `preferredSources: BookSourceId[]` field to the Preferences model with validation against `BOOK_SOURCES`
- Add `StorePreferencesScreen` with per-store Switch toggles (博客來, 金石堂, 城邦讀書花園, 誠品線上)
- Add navigation route and link from Settings screen showing selected count summary
- Filter offers in `SearchResultScreen` by preferred sources (empty selection = show all)
- Add i18n strings for zh-TW and en
- Add 5 focused tests for toggle behavior; update existing test mocks for new preference field

---
[Warp conversation](https://app.warp.dev/conversation/983ddc25-e757-4f5b-bb16-5f03facb5bb6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Oz <oz-agent@warp.dev>