### PR TITLE
feat(mobile): add iCloud sync and reset controls

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -39,6 +39,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     bundleIdentifier: 'com.andrewmmc.BookPriceApp',
     buildNumber: iosBuildNumber,
     supportsTablet: false,
+    entitlements: {
+      'com.apple.developer.ubiquity-kvstore-identifier':
+        '$(TeamIdentifierPrefix)$(CFBundleIdentifier)',
+    },
     infoPlist: {
       CFBundleDevelopmentRegion: 'zh_Hant_TW',
       ITSAppUsesNonExemptEncryption: false,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -29,6 +29,7 @@
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
+    "expo-icloud-storage": "^0.1.1",
     "expo-localization": "^17.0.8",
     "expo-status-bar": "~3.0.9",
     "posthog-react-native": "^4.43.10",

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -64,12 +64,10 @@ function AppContent() {
 
   useEffect(() => {
     if (!preferencesLoaded) {
-      setIcloudSyncReady(false);
       return;
     }
 
     let cancelled = false;
-    setIcloudSyncReady(false);
     void runInitialIcloudSync()
       .then((syncResult) => {
         if (cancelled) {

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -73,10 +73,10 @@ function AppContent() {
         if (cancelled) {
           return;
         }
-        if (syncResult.history) {
+        if (syncResult.history !== undefined) {
           queryClient.setQueryData(HISTORY_QUERY_KEY, syncResult.history);
         }
-        if (syncResult.favourites) {
+        if (syncResult.favourites !== undefined) {
           queryClient.setQueryData(FAVOURITES_QUERY_KEY, syncResult.favourites);
         }
       })

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -2,14 +2,17 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StatusBar } from 'expo-status-bar';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { initAnalytics, registerAnalyticsProperties } from './analytics';
+import { FAVOURITES_QUERY_KEY } from './api/favourites';
+import { HISTORY_QUERY_KEY } from './api/history';
 import { strings } from './i18n/strings';
+import { runInitialIcloudSync } from './lib/icloudSync';
 import { usePreferencesLoaded } from './lib/preferences';
 import { RootNavigator } from './navigation/RootNavigator';
 import { spacing } from './theme/spacing';
@@ -52,11 +55,43 @@ function AppContent() {
   const { colors, scheme } = useTheme();
   const paperTheme = scheme === 'dark' ? paperThemeDark : paperThemeLight;
   const preferencesLoaded = usePreferencesLoaded();
+  const [icloudSyncReady, setIcloudSyncReady] = useState(false);
 
   useEffect(() => {
     initAnalytics();
     registerAnalyticsProperties({ themeScheme: scheme });
   }, [scheme]);
+
+  useEffect(() => {
+    if (!preferencesLoaded) {
+      setIcloudSyncReady(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIcloudSyncReady(false);
+    void runInitialIcloudSync()
+      .then((syncResult) => {
+        if (cancelled) {
+          return;
+        }
+        if (syncResult.history) {
+          queryClient.setQueryData(HISTORY_QUERY_KEY, syncResult.history);
+        }
+        if (syncResult.favourites) {
+          queryClient.setQueryData(FAVOURITES_QUERY_KEY, syncResult.favourites);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIcloudSyncReady(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [preferencesLoaded]);
 
   const navigationTheme = useMemo(
     () => ({
@@ -79,7 +114,7 @@ function AppContent() {
       <ActionSheetProvider>
         <NavigationContainer theme={navigationTheme}>
           <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
-          {preferencesLoaded ? <RootNavigator /> : <AppStartupSkeleton />}
+          {preferencesLoaded && icloudSyncReady ? <RootNavigator /> : <AppStartupSkeleton />}
         </NavigationContainer>
       </ActionSheetProvider>
     </PaperProvider>

--- a/apps/mobile/src/api/favourites.ts
+++ b/apps/mobile/src/api/favourites.ts
@@ -7,6 +7,7 @@ import {
   removeFavourite,
   type Favourite,
 } from '../lib/favourites';
+import { syncFavouritesToIcloud } from '../lib/icloudSync';
 
 import { normalizeIsbn } from '@bookscompare/contracts';
 
@@ -36,6 +37,11 @@ export function useAddFavourite() {
     mutationFn: (input: { isbn: string; title: string }) => addFavourite(input),
     onSuccess: (next) => {
       queryClient.setQueryData<Favourite[]>(FAVOURITES_QUERY_KEY, next);
+      void syncFavouritesToIcloud(next).then((synced) => {
+        if (synced) {
+          queryClient.setQueryData<Favourite[]>(FAVOURITES_QUERY_KEY, synced);
+        }
+      });
     },
   });
 }
@@ -46,6 +52,7 @@ export function useRemoveFavourite() {
     mutationFn: (isbn: string) => removeFavourite(isbn),
     onSuccess: (next) => {
       queryClient.setQueryData<Favourite[]>(FAVOURITES_QUERY_KEY, next);
+      void syncFavouritesToIcloud(next, { mergeRemote: false });
     },
   });
 }
@@ -56,6 +63,7 @@ export function useClearFavourites() {
     mutationFn: () => clearFavourites(),
     onSuccess: (next) => {
       queryClient.setQueryData<Favourite[]>(FAVOURITES_QUERY_KEY, next);
+      void syncFavouritesToIcloud(next, { mergeRemote: false });
     },
   });
 }

--- a/apps/mobile/src/api/history.ts
+++ b/apps/mobile/src/api/history.ts
@@ -7,6 +7,7 @@ import {
   type HistoryEntry,
   type HistoryInput,
 } from '../lib/history';
+import { syncHistoryToIcloud } from '../lib/icloudSync';
 
 export const HISTORY_QUERY_KEY = ['history'] as const;
 
@@ -24,6 +25,11 @@ export function useAddHistoryEntry() {
     mutationFn: (input: HistoryInput) => addHistoryEntry(input),
     onSuccess: (next) => {
       queryClient.setQueryData<HistoryEntry[]>(HISTORY_QUERY_KEY, next);
+      void syncHistoryToIcloud(next).then((synced) => {
+        if (synced) {
+          queryClient.setQueryData<HistoryEntry[]>(HISTORY_QUERY_KEY, synced);
+        }
+      });
     },
   });
 }
@@ -34,6 +40,7 @@ export function useClearHistory() {
     mutationFn: () => clearHistory(),
     onSuccess: (next) => {
       queryClient.setQueryData<HistoryEntry[]>(HISTORY_QUERY_KEY, next);
+      void syncHistoryToIcloud(next, { mergeRemote: false });
     },
   });
 }

--- a/apps/mobile/src/i18n/dictionaries.ts
+++ b/apps/mobile/src/i18n/dictionaries.ts
@@ -116,6 +116,7 @@ interface Dictionary {
     appearanceSection: string;
     contentSection: string;
     syncSection: string;
+    dataSection: string;
     openLinksIn: string;
     openLinksDescription: string;
     openLinksInApp: string;
@@ -133,6 +134,11 @@ interface Dictionary {
     icloudSync: string;
     icloudSyncOn: string;
     icloudSyncOff: string;
+    resetAllData: string;
+    resetAllDataConfirmTitle: string;
+    resetAllDataConfirmMessage: string;
+    resetAllDataConfirmMessageWithIcloud: string;
+    resetAllDataConfirmAction: string;
     cancelAction: string;
   };
   storePreferences: {
@@ -288,6 +294,7 @@ const zhTW: Dictionary = {
     appearanceSection: '外觀',
     contentSection: '內容',
     syncSection: '同步',
+    dataSection: '資料',
     openLinksIn: '開啟連結',
     openLinksDescription: '選擇點開書店連結時要在 App 內顯示，還是交由瀏覽器開啟。',
     openLinksInApp: '在 App 內開啟',
@@ -305,6 +312,12 @@ const zhTW: Dictionary = {
     icloudSync: 'iCloud 同步',
     icloudSyncOn: '開啟',
     icloudSyncOff: '關閉',
+    resetAllData: '重設所有資料',
+    resetAllDataConfirmTitle: '重設所有資料？',
+    resetAllDataConfirmMessage: '此動作無法復原，所有本機設定、搜尋記錄與收藏都會被移除。',
+    resetAllDataConfirmMessageWithIcloud:
+      '此動作無法復原，所有本機設定、搜尋記錄與收藏都會被移除，並同時清除 iCloud 上的同步資料。',
+    resetAllDataConfirmAction: '重設',
     cancelAction: '取消',
   },
   storePreferences: {
@@ -463,6 +476,7 @@ const en: Dictionary = {
     appearanceSection: 'Appearance',
     contentSection: 'Content',
     syncSection: 'Sync',
+    dataSection: 'Data',
     openLinksIn: 'Open links',
     openLinksDescription: 'Choose whether bookstore links open inside the app or in your browser.',
     openLinksInApp: 'In app',
@@ -481,6 +495,13 @@ const en: Dictionary = {
     icloudSync: 'iCloud Sync',
     icloudSyncOn: 'On',
     icloudSyncOff: 'Off',
+    resetAllData: 'Reset all data',
+    resetAllDataConfirmTitle: 'Reset all data?',
+    resetAllDataConfirmMessage:
+      'This cannot be undone. All local settings, history, and favourites will be removed.',
+    resetAllDataConfirmMessageWithIcloud:
+      'This cannot be undone. All local settings, history, and favourites will be removed, and synced iCloud data will be deleted too.',
+    resetAllDataConfirmAction: 'Reset',
     cancelAction: 'Cancel',
   },
   storePreferences: {

--- a/apps/mobile/src/i18n/dictionaries.ts
+++ b/apps/mobile/src/i18n/dictionaries.ts
@@ -115,6 +115,7 @@ interface Dictionary {
     generalSection: string;
     appearanceSection: string;
     contentSection: string;
+    syncSection: string;
     openLinksIn: string;
     openLinksDescription: string;
     openLinksInApp: string;
@@ -129,6 +130,9 @@ interface Dictionary {
     bookTypeAll: string;
     bookTypePhysical: string;
     bookTypeEbook: string;
+    icloudSync: string;
+    icloudSyncOn: string;
+    icloudSyncOff: string;
     cancelAction: string;
   };
   storePreferences: {
@@ -283,6 +287,7 @@ const zhTW: Dictionary = {
     generalSection: '一般',
     appearanceSection: '外觀',
     contentSection: '內容',
+    syncSection: '同步',
     openLinksIn: '開啟連結',
     openLinksDescription: '選擇點開書店連結時要在 App 內顯示，還是交由瀏覽器開啟。',
     openLinksInApp: '在 App 內開啟',
@@ -297,6 +302,9 @@ const zhTW: Dictionary = {
     bookTypeAll: '全部',
     bookTypePhysical: '實體書',
     bookTypeEbook: '電子書',
+    icloudSync: 'iCloud 同步',
+    icloudSyncOn: '開啟',
+    icloudSyncOff: '關閉',
     cancelAction: '取消',
   },
   storePreferences: {
@@ -454,6 +462,7 @@ const en: Dictionary = {
     generalSection: 'General',
     appearanceSection: 'Appearance',
     contentSection: 'Content',
+    syncSection: 'Sync',
     openLinksIn: 'Open links',
     openLinksDescription: 'Choose whether bookstore links open inside the app or in your browser.',
     openLinksInApp: 'In app',
@@ -469,6 +478,9 @@ const en: Dictionary = {
     bookTypeAll: 'All',
     bookTypePhysical: 'Physical books',
     bookTypeEbook: 'eBooks',
+    icloudSync: 'iCloud Sync',
+    icloudSyncOn: 'On',
+    icloudSyncOff: 'Off',
     cancelAction: 'Cancel',
   },
   storePreferences: {

--- a/apps/mobile/src/lib/appData.test.ts
+++ b/apps/mobile/src/lib/appData.test.ts
@@ -1,0 +1,41 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { addFavourite, loadFavourites } from './favourites';
+import { addHistoryEntry, loadHistory } from './history';
+import { resetAppData } from './appData';
+import { loadPreferences, updatePreference } from './preferences';
+
+describe('app data reset', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('resets preferences, history, and favourites to defaults', async () => {
+    await updatePreference('openLinksIn', 'browser');
+    await updatePreference('themeMode', 'dark');
+    await addHistoryEntry({ type: 'title', title: '設計模式' });
+    await addFavourite({ isbn: '9786264560092', title: '重構' });
+
+    await expect(resetAppData()).resolves.toEqual({
+      preferences: {
+        openLinksIn: 'app',
+        themeMode: 'system',
+        preferredSources: [],
+        preferredBookTypes: [],
+        icloudSyncEnabled: true,
+      },
+      history: [],
+      favourites: [],
+    });
+
+    await expect(loadPreferences()).resolves.toEqual({
+      openLinksIn: 'app',
+      themeMode: 'system',
+      preferredSources: [],
+      preferredBookTypes: [],
+      icloudSyncEnabled: true,
+    });
+    await expect(loadHistory()).resolves.toEqual([]);
+    await expect(loadFavourites()).resolves.toEqual([]);
+  });
+});

--- a/apps/mobile/src/lib/appData.ts
+++ b/apps/mobile/src/lib/appData.ts
@@ -1,0 +1,19 @@
+import { clearFavourites, type Favourite } from './favourites';
+import { clearHistory, type HistoryEntry } from './history';
+import { DEFAULT_PREFERENCES, replacePreferences, type Preferences } from './preferences';
+
+export interface ResetAppDataResult {
+  preferences: Preferences;
+  history: HistoryEntry[];
+  favourites: Favourite[];
+}
+
+export async function resetAppData(): Promise<ResetAppDataResult> {
+  const [preferences, history, favourites] = await Promise.all([
+    replacePreferences({ ...DEFAULT_PREFERENCES }),
+    clearHistory(),
+    clearFavourites(),
+  ]);
+
+  return { preferences, history, favourites };
+}

--- a/apps/mobile/src/lib/favourites.ts
+++ b/apps/mobile/src/lib/favourites.ts
@@ -28,7 +28,7 @@ function isFavourite(value: unknown): value is Favourite {
   );
 }
 
-function parseFavourites(value: unknown): Favourite[] {
+export function parseFavourites(value: unknown): Favourite[] {
   if (!Array.isArray(value)) {
     return [];
   }
@@ -42,6 +42,11 @@ export async function loadFavourites(): Promise<Favourite[]> {
 
 async function saveFavourites(list: Favourite[]): Promise<void> {
   await saveJsonValue(FAVOURITES_STORAGE_KEY, list);
+}
+
+export async function replaceFavourites(list: Favourite[]): Promise<Favourite[]> {
+  await saveFavourites(list);
+  return list;
 }
 
 export async function addFavourite(input: FavouriteInput): Promise<Favourite[]> {

--- a/apps/mobile/src/lib/history.ts
+++ b/apps/mobile/src/lib/history.ts
@@ -10,7 +10,8 @@ export type HistoryEntry =
   | { type: 'title'; title: string; viewedAt: number };
 
 export type HistoryInput =
-  { type: 'isbn'; isbn: string; title?: string } | { type: 'title'; title: string };
+  | { type: 'isbn'; isbn: string; title?: string }
+  | { type: 'title'; title: string };
 
 export function parseHistory(value: unknown): HistoryEntry[] {
   if (!Array.isArray(value)) {

--- a/apps/mobile/src/lib/history.ts
+++ b/apps/mobile/src/lib/history.ts
@@ -10,10 +10,9 @@ export type HistoryEntry =
   | { type: 'title'; title: string; viewedAt: number };
 
 export type HistoryInput =
-  | { type: 'isbn'; isbn: string; title?: string }
-  | { type: 'title'; title: string };
+  { type: 'isbn'; isbn: string; title?: string } | { type: 'title'; title: string };
 
-function parseHistory(value: unknown): HistoryEntry[] {
+export function parseHistory(value: unknown): HistoryEntry[] {
   if (!Array.isArray(value)) {
     return [];
   }
@@ -47,6 +46,11 @@ export async function loadHistory(): Promise<HistoryEntry[]> {
 
 async function saveHistory(list: HistoryEntry[]): Promise<void> {
   await saveJsonValue(HISTORY_STORAGE_KEY, list);
+}
+
+export async function replaceHistory(list: HistoryEntry[]): Promise<HistoryEntry[]> {
+  await saveHistory(list);
+  return list;
 }
 
 function isSameEntry(a: HistoryEntry, b: HistoryEntry): boolean {

--- a/apps/mobile/src/lib/icloudStorage.ts
+++ b/apps/mobile/src/lib/icloudStorage.ts
@@ -1,3 +1,4 @@
+import { requireOptionalNativeModule } from 'expo';
 import { Platform } from 'react-native';
 
 interface IcloudStorageModule {
@@ -6,16 +7,6 @@ interface IcloudStorageModule {
   remove(key: string): void;
   getAllKeys(): string[];
 }
-
-interface IcloudStorageModuleImport {
-  default?: IcloudStorageModule;
-  set?: IcloudStorageModule['set'];
-  getString?: IcloudStorageModule['getString'];
-  remove?: IcloudStorageModule['remove'];
-  getAllKeys?: IcloudStorageModule['getAllKeys'];
-}
-
-declare const require: (id: string) => IcloudStorageModuleImport;
 
 let cachedStorage: IcloudStorageModule | null | undefined;
 
@@ -29,22 +20,12 @@ function loadStorage(): IcloudStorageModule | null {
   }
 
   try {
-    const module = require('expo-icloud-storage');
-    cachedStorage = module.default ?? (isIcloudStorageModule(module) ? module : null);
+    cachedStorage = requireOptionalNativeModule<IcloudStorageModule>('ExpoAppleCloudStorage');
   } catch {
     cachedStorage = null;
   }
 
   return cachedStorage ?? null;
-}
-
-function isIcloudStorageModule(value: IcloudStorageModuleImport): value is IcloudStorageModule {
-  return (
-    typeof value.set === 'function' &&
-    typeof value.getString === 'function' &&
-    typeof value.remove === 'function' &&
-    typeof value.getAllKeys === 'function'
-  );
 }
 
 export function isIcloudStorageAvailable(): boolean {

--- a/apps/mobile/src/lib/icloudStorage.ts
+++ b/apps/mobile/src/lib/icloudStorage.ts
@@ -52,7 +52,11 @@ export function isIcloudStorageAvailable(): boolean {
 }
 
 export function getIcloudString(key: string): string | null {
-  return loadStorage()?.getString(key) ?? null;
+  try {
+    return loadStorage()?.getString(key) ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export function setIcloudString(key: string, value: string): boolean {
@@ -61,8 +65,12 @@ export function setIcloudString(key: string, value: string): boolean {
     return false;
   }
 
-  storage.set(key, value);
-  return true;
+  try {
+    storage.set(key, value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function removeIcloudValue(key: string): boolean {
@@ -71,6 +79,10 @@ export function removeIcloudValue(key: string): boolean {
     return false;
   }
 
-  storage.remove(key);
-  return true;
+  try {
+    storage.remove(key);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/apps/mobile/src/lib/icloudStorage.ts
+++ b/apps/mobile/src/lib/icloudStorage.ts
@@ -1,0 +1,76 @@
+import { Platform } from 'react-native';
+
+interface IcloudStorageModule {
+  set(key: string, value: string): void;
+  getString(key: string): string | null;
+  remove(key: string): void;
+  getAllKeys(): string[];
+}
+
+interface IcloudStorageModuleImport {
+  default?: IcloudStorageModule;
+  set?: IcloudStorageModule['set'];
+  getString?: IcloudStorageModule['getString'];
+  remove?: IcloudStorageModule['remove'];
+  getAllKeys?: IcloudStorageModule['getAllKeys'];
+}
+
+declare const require: (id: string) => IcloudStorageModuleImport;
+
+let cachedStorage: IcloudStorageModule | null | undefined;
+
+function loadStorage(): IcloudStorageModule | null {
+  if (Platform.OS !== 'ios') {
+    return null;
+  }
+
+  if (cachedStorage !== undefined) {
+    return cachedStorage;
+  }
+
+  try {
+    const module = require('expo-icloud-storage');
+    cachedStorage = module.default ?? (isIcloudStorageModule(module) ? module : null);
+  } catch {
+    cachedStorage = null;
+  }
+
+  return cachedStorage ?? null;
+}
+
+function isIcloudStorageModule(value: IcloudStorageModuleImport): value is IcloudStorageModule {
+  return (
+    typeof value.set === 'function' &&
+    typeof value.getString === 'function' &&
+    typeof value.remove === 'function' &&
+    typeof value.getAllKeys === 'function'
+  );
+}
+
+export function isIcloudStorageAvailable(): boolean {
+  return loadStorage() !== null;
+}
+
+export function getIcloudString(key: string): string | null {
+  return loadStorage()?.getString(key) ?? null;
+}
+
+export function setIcloudString(key: string, value: string): boolean {
+  const storage = loadStorage();
+  if (!storage) {
+    return false;
+  }
+
+  storage.set(key, value);
+  return true;
+}
+
+export function removeIcloudValue(key: string): boolean {
+  const storage = loadStorage();
+  if (!storage) {
+    return false;
+  }
+
+  storage.remove(key);
+  return true;
+}

--- a/apps/mobile/src/lib/icloudSync.test.ts
+++ b/apps/mobile/src/lib/icloudSync.test.ts
@@ -1,0 +1,55 @@
+import { HISTORY_MAX_ENTRIES, type HistoryEntry } from './history';
+import { mergeFavourites, mergeHistoryEntries } from './icloudSync';
+
+describe('iCloud sync merge helpers', () => {
+  it('merges history by identity, keeps newest entries, and preserves ISBN titles', () => {
+    const local: HistoryEntry[] = [
+      { type: 'isbn', isbn: '9786264560092', title: 'Local title', viewedAt: 200 },
+      { type: 'title', title: '  TypeScript  ', viewedAt: 100 },
+    ];
+    const remote: HistoryEntry[] = [
+      { type: 'isbn', isbn: '9786264560092', viewedAt: 300 },
+      { type: 'title', title: 'typescript', viewedAt: 250 },
+      { type: 'title', title: 'React Native', viewedAt: 150 },
+    ];
+
+    expect(mergeHistoryEntries(local, remote)).toEqual([
+      { type: 'isbn', isbn: '9786264560092', viewedAt: 300, title: 'Local title' },
+      { type: 'title', title: 'typescript', viewedAt: 250 },
+      { type: 'title', title: 'React Native', viewedAt: 150 },
+    ]);
+  });
+
+  it('caps merged history at the existing history limit', () => {
+    const local: HistoryEntry[] = Array.from({ length: HISTORY_MAX_ENTRIES + 5 }, (_, index) => ({
+      type: 'title',
+      title: `Book ${index}`,
+      viewedAt: index,
+    }));
+
+    const merged = mergeHistoryEntries(local, []);
+
+    expect(merged).toHaveLength(HISTORY_MAX_ENTRIES);
+    expect(merged[0]?.title).toBe(`Book ${HISTORY_MAX_ENTRIES + 4}`);
+    expect(merged.at(-1)?.title).toBe('Book 5');
+  });
+
+  it('merges favourites by normalized ISBN and keeps newest entries first', () => {
+    const merged = mergeFavourites(
+      [
+        { isbn: '978-626-456-009-2', title: 'Local newer', addedAt: 300 },
+        { isbn: '9789865254483', title: 'Local only', addedAt: 100 },
+      ],
+      [
+        { isbn: '9786264560092', title: 'Remote older', addedAt: 200 },
+        { isbn: '9786267468296', title: 'Remote only', addedAt: 250 },
+      ]
+    );
+
+    expect(merged).toEqual([
+      { isbn: '9786264560092', title: 'Local newer', addedAt: 300 },
+      { isbn: '9786267468296', title: 'Remote only', addedAt: 250 },
+      { isbn: '9789865254483', title: 'Local only', addedAt: 100 },
+    ]);
+  });
+});

--- a/apps/mobile/src/lib/icloudSync.ts
+++ b/apps/mobile/src/lib/icloudSync.ts
@@ -18,7 +18,12 @@ import {
   type Preferences,
   type SyncablePreferences,
 } from './preferences';
-import { getIcloudString, isIcloudStorageAvailable, setIcloudString } from './icloudStorage';
+import {
+  getIcloudString,
+  isIcloudStorageAvailable,
+  removeIcloudValue,
+  setIcloudString,
+} from './icloudStorage';
 
 export const ICLOUD_PREFERENCES_KEY = 'bookscompare:icloud:preferences:v1';
 export const ICLOUD_HISTORY_KEY = 'bookscompare:icloud:history:v1';
@@ -220,6 +225,12 @@ export async function syncFavouritesToIcloud(
   const next = remote ? mergeFavourites(favourites, remote.value) : favourites;
   writePayload(ICLOUD_FAVOURITES_KEY, Date.now(), next);
   return next;
+}
+
+export async function clearIcloudData(): Promise<void> {
+  removeIcloudValue(ICLOUD_PREFERENCES_KEY);
+  removeIcloudValue(ICLOUD_HISTORY_KEY);
+  removeIcloudValue(ICLOUD_FAVOURITES_KEY);
 }
 
 export async function runInitialIcloudSync(): Promise<InitialIcloudSyncResult> {

--- a/apps/mobile/src/lib/icloudSync.ts
+++ b/apps/mobile/src/lib/icloudSync.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-import { normalizeIsbn } from '@bookscompare/contracts';
+import { BOOK_SOURCES, normalizeIsbn } from '@bookscompare/contracts';
 
 import { loadFavourites, parseFavourites, replaceFavourites, type Favourite } from './favourites';
 import {
@@ -24,16 +24,22 @@ export const ICLOUD_PREFERENCES_KEY = 'bookscompare:icloud:preferences:v1';
 export const ICLOUD_HISTORY_KEY = 'bookscompare:icloud:history:v1';
 export const ICLOUD_FAVOURITES_KEY = 'bookscompare:icloud:favourites:v1';
 
+const validSourceIds = new Set<string>(BOOK_SOURCES.map((source) => source.id));
+
 interface IcloudPayload<T> {
   schemaVersion: 1;
   updatedAt: number;
   value: T;
 }
 
-interface InitialIcloudSyncResult {
+export interface InitialIcloudSyncResult {
   preferences?: Preferences;
   history?: HistoryEntry[];
   favourites?: Favourite[];
+}
+
+interface SyncListOptions {
+  mergeRemote?: boolean;
 }
 
 function canUseIcloudSync(preferences: Preferences): boolean {
@@ -91,16 +97,23 @@ function parseSyncablePreferences(value: unknown): SyncablePreferences {
   }
 
   const record = value as Record<string, unknown>;
+  const preferredBookTypes = Array.isArray(record.preferredBookTypes)
+    ? record.preferredBookTypes.filter((value) => value === 'physical' || value === 'ebook')
+    : [];
+
   return toSyncablePreferences({
     openLinksIn: record.openLinksIn === 'browser' ? 'browser' : 'app',
     themeMode:
       record.themeMode === 'light' || record.themeMode === 'dark' || record.themeMode === 'system'
         ? record.themeMode
         : 'system',
-    preferredSources: Array.isArray(record.preferredSources) ? record.preferredSources : [],
-    preferredBookTypes: Array.isArray(record.preferredBookTypes)
-      ? record.preferredBookTypes.filter((value) => value === 'physical' || value === 'ebook')
+    preferredSources: Array.isArray(record.preferredSources)
+      ? record.preferredSources.filter(
+          (value): value is Preferences['preferredSources'][number] =>
+            typeof value === 'string' && validSourceIds.has(value)
+        )
       : [],
+    preferredBookTypes: Array.from(new Set(preferredBookTypes)),
     icloudSyncEnabled: true,
   } as Preferences);
 }
@@ -173,26 +186,40 @@ export async function syncPreferencesToIcloud(preferences: Preferences): Promise
   writePayload(ICLOUD_PREFERENCES_KEY, updatedAt || Date.now(), toSyncablePreferences(preferences));
 }
 
-export async function syncHistoryToIcloud(history: HistoryEntry[]): Promise<void> {
+export async function syncHistoryToIcloud(
+  history: HistoryEntry[],
+  options: SyncListOptions = {}
+): Promise<HistoryEntry[] | null> {
   const preferences = await loadPreferences();
   if (!canUseIcloudSync(preferences)) {
-    return;
+    return null;
   }
 
-  const remote = parseJsonPayload(getIcloudString(ICLOUD_HISTORY_KEY), parseHistory);
-  const merged = remote ? mergeHistoryEntries(history, remote.value) : history;
-  writePayload(ICLOUD_HISTORY_KEY, Date.now(), merged);
+  const shouldMergeRemote = options.mergeRemote ?? true;
+  const remote = shouldMergeRemote
+    ? parseJsonPayload(getIcloudString(ICLOUD_HISTORY_KEY), parseHistory)
+    : null;
+  const next = remote ? mergeHistoryEntries(history, remote.value) : history;
+  writePayload(ICLOUD_HISTORY_KEY, Date.now(), next);
+  return next;
 }
 
-export async function syncFavouritesToIcloud(favourites: Favourite[]): Promise<void> {
+export async function syncFavouritesToIcloud(
+  favourites: Favourite[],
+  options: SyncListOptions = {}
+): Promise<Favourite[] | null> {
   const preferences = await loadPreferences();
   if (!canUseIcloudSync(preferences)) {
-    return;
+    return null;
   }
 
-  const remote = parseJsonPayload(getIcloudString(ICLOUD_FAVOURITES_KEY), parseFavourites);
-  const merged = remote ? mergeFavourites(favourites, remote.value) : favourites;
-  writePayload(ICLOUD_FAVOURITES_KEY, Date.now(), merged);
+  const shouldMergeRemote = options.mergeRemote ?? true;
+  const remote = shouldMergeRemote
+    ? parseJsonPayload(getIcloudString(ICLOUD_FAVOURITES_KEY), parseFavourites)
+    : null;
+  const next = remote ? mergeFavourites(favourites, remote.value) : favourites;
+  writePayload(ICLOUD_FAVOURITES_KEY, Date.now(), next);
+  return next;
 }
 
 export async function runInitialIcloudSync(): Promise<InitialIcloudSyncResult> {

--- a/apps/mobile/src/lib/icloudSync.ts
+++ b/apps/mobile/src/lib/icloudSync.ts
@@ -1,0 +1,257 @@
+import { Platform } from 'react-native';
+
+import { normalizeIsbn } from '@bookscompare/contracts';
+
+import { loadFavourites, parseFavourites, replaceFavourites, type Favourite } from './favourites';
+import {
+  loadHistory,
+  parseHistory,
+  replaceHistory,
+  HISTORY_MAX_ENTRIES,
+  type HistoryEntry,
+} from './history';
+import {
+  loadPreferences,
+  loadPreferencesUpdatedAt,
+  replacePreferences,
+  toSyncablePreferences,
+  type Preferences,
+  type SyncablePreferences,
+} from './preferences';
+import { getIcloudString, isIcloudStorageAvailable, setIcloudString } from './icloudStorage';
+
+export const ICLOUD_PREFERENCES_KEY = 'bookscompare:icloud:preferences:v1';
+export const ICLOUD_HISTORY_KEY = 'bookscompare:icloud:history:v1';
+export const ICLOUD_FAVOURITES_KEY = 'bookscompare:icloud:favourites:v1';
+
+interface IcloudPayload<T> {
+  schemaVersion: 1;
+  updatedAt: number;
+  value: T;
+}
+
+interface InitialIcloudSyncResult {
+  preferences?: Preferences;
+  history?: HistoryEntry[];
+  favourites?: Favourite[];
+}
+
+function canUseIcloudSync(preferences: Preferences): boolean {
+  return Platform.OS === 'ios' && preferences.icloudSyncEnabled && isIcloudStorageAvailable();
+}
+
+function parseJsonPayload<T>(
+  raw: string | null,
+  parseValue: (value: unknown) => T
+): IcloudPayload<T> | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      parsed.schemaVersion !== 1 ||
+      typeof parsed.updatedAt !== 'number' ||
+      !Number.isFinite(parsed.updatedAt)
+    ) {
+      return null;
+    }
+
+    return {
+      schemaVersion: 1,
+      updatedAt: parsed.updatedAt,
+      value: parseValue(parsed.value),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writePayload<T>(key: string, updatedAt: number, value: T): boolean {
+  return setIcloudString(
+    key,
+    JSON.stringify({
+      schemaVersion: 1,
+      updatedAt,
+      value,
+    })
+  );
+}
+
+function hasSameJsonValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function parseSyncablePreferences(value: unknown): SyncablePreferences {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid iCloud preferences payload');
+  }
+
+  const record = value as Record<string, unknown>;
+  return toSyncablePreferences({
+    openLinksIn: record.openLinksIn === 'browser' ? 'browser' : 'app',
+    themeMode:
+      record.themeMode === 'light' || record.themeMode === 'dark' || record.themeMode === 'system'
+        ? record.themeMode
+        : 'system',
+    preferredSources: Array.isArray(record.preferredSources) ? record.preferredSources : [],
+    preferredBookTypes: Array.isArray(record.preferredBookTypes)
+      ? record.preferredBookTypes.filter((value) => value === 'physical' || value === 'ebook')
+      : [],
+    icloudSyncEnabled: true,
+  } as Preferences);
+}
+
+function normalizeTitle(title: string): string {
+  return title.trim().toLocaleLowerCase();
+}
+
+function historyIdentity(entry: HistoryEntry): string {
+  return entry.type === 'isbn' ? `isbn:${entry.isbn}` : `title:${normalizeTitle(entry.title)}`;
+}
+
+export function mergeHistoryEntries(
+  localEntries: HistoryEntry[],
+  remoteEntries: HistoryEntry[]
+): HistoryEntry[] {
+  const byIdentity = new Map<string, HistoryEntry>();
+
+  [...remoteEntries, ...localEntries].forEach((entry) => {
+    const key = historyIdentity(entry);
+    const existing = byIdentity.get(key);
+    if (!existing || entry.viewedAt > existing.viewedAt) {
+      byIdentity.set(key, entry);
+      return;
+    }
+
+    if (existing.type === 'isbn' && entry.type === 'isbn' && !existing.title && entry.title) {
+      byIdentity.set(key, { ...existing, title: entry.title });
+    }
+  });
+
+  return Array.from(byIdentity.values())
+    .sort((a, b) => b.viewedAt - a.viewedAt)
+    .slice(0, HISTORY_MAX_ENTRIES);
+}
+
+export function mergeFavourites(
+  localFavourites: Favourite[],
+  remoteFavourites: Favourite[]
+): Favourite[] {
+  const byIsbn = new Map<string, Favourite>();
+
+  [...remoteFavourites, ...localFavourites].forEach((favourite) => {
+    const isbn = normalizeIsbn(favourite.isbn);
+    if (!isbn) {
+      return;
+    }
+
+    const normalized = { ...favourite, isbn };
+    const existing = byIsbn.get(isbn);
+    if (!existing || normalized.addedAt > existing.addedAt) {
+      byIsbn.set(isbn, normalized);
+      return;
+    }
+
+    if (!existing.title && normalized.title) {
+      byIsbn.set(isbn, { ...existing, title: normalized.title });
+    }
+  });
+
+  return Array.from(byIsbn.values()).sort((a, b) => b.addedAt - a.addedAt);
+}
+
+export async function syncPreferencesToIcloud(preferences: Preferences): Promise<void> {
+  if (!canUseIcloudSync(preferences)) {
+    return;
+  }
+
+  const updatedAt = await loadPreferencesUpdatedAt();
+  writePayload(ICLOUD_PREFERENCES_KEY, updatedAt || Date.now(), toSyncablePreferences(preferences));
+}
+
+export async function syncHistoryToIcloud(history: HistoryEntry[]): Promise<void> {
+  const preferences = await loadPreferences();
+  if (!canUseIcloudSync(preferences)) {
+    return;
+  }
+
+  const remote = parseJsonPayload(getIcloudString(ICLOUD_HISTORY_KEY), parseHistory);
+  const merged = remote ? mergeHistoryEntries(history, remote.value) : history;
+  writePayload(ICLOUD_HISTORY_KEY, Date.now(), merged);
+}
+
+export async function syncFavouritesToIcloud(favourites: Favourite[]): Promise<void> {
+  const preferences = await loadPreferences();
+  if (!canUseIcloudSync(preferences)) {
+    return;
+  }
+
+  const remote = parseJsonPayload(getIcloudString(ICLOUD_FAVOURITES_KEY), parseFavourites);
+  const merged = remote ? mergeFavourites(favourites, remote.value) : favourites;
+  writePayload(ICLOUD_FAVOURITES_KEY, Date.now(), merged);
+}
+
+export async function runInitialIcloudSync(): Promise<InitialIcloudSyncResult> {
+  const preferences = await loadPreferences();
+  if (!canUseIcloudSync(preferences)) {
+    return {};
+  }
+
+  const result: InitialIcloudSyncResult = {};
+  const localPreferencesUpdatedAt = await loadPreferencesUpdatedAt();
+  const remotePreferences = parseJsonPayload(
+    getIcloudString(ICLOUD_PREFERENCES_KEY),
+    parseSyncablePreferences
+  );
+  const nextPreferences =
+    remotePreferences && remotePreferences.updatedAt > localPreferencesUpdatedAt
+      ? { ...remotePreferences.value, icloudSyncEnabled: preferences.icloudSyncEnabled }
+      : preferences;
+  const nextPreferencesUpdatedAt = Math.max(
+    localPreferencesUpdatedAt,
+    remotePreferences?.updatedAt ?? 0,
+    Date.now()
+  );
+
+  if (!hasSameJsonValue(nextPreferences, preferences)) {
+    result.preferences = await replacePreferences(nextPreferences, nextPreferencesUpdatedAt);
+  }
+  writePayload(
+    ICLOUD_PREFERENCES_KEY,
+    nextPreferencesUpdatedAt,
+    toSyncablePreferences(nextPreferences)
+  );
+
+  const localHistory = await loadHistory();
+  const remoteHistory = parseJsonPayload(getIcloudString(ICLOUD_HISTORY_KEY), parseHistory);
+  const nextHistory = remoteHistory
+    ? mergeHistoryEntries(localHistory, remoteHistory.value)
+    : localHistory;
+  if (!hasSameJsonValue(nextHistory, localHistory)) {
+    result.history = await replaceHistory(nextHistory);
+  } else {
+    result.history = nextHistory;
+  }
+  writePayload(ICLOUD_HISTORY_KEY, Date.now(), nextHistory);
+
+  const localFavourites = await loadFavourites();
+  const remoteFavourites = parseJsonPayload(
+    getIcloudString(ICLOUD_FAVOURITES_KEY),
+    parseFavourites
+  );
+  const nextFavourites = remoteFavourites
+    ? mergeFavourites(localFavourites, remoteFavourites.value)
+    : localFavourites;
+  if (!hasSameJsonValue(nextFavourites, localFavourites)) {
+    result.favourites = await replaceFavourites(nextFavourites);
+  } else {
+    result.favourites = nextFavourites;
+  }
+  writePayload(ICLOUD_FAVOURITES_KEY, Date.now(), nextFavourites);
+
+  return result;
+}

--- a/apps/mobile/src/lib/preferences.test.ts
+++ b/apps/mobile/src/lib/preferences.test.ts
@@ -30,6 +30,7 @@ describe('preferences storage', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 
@@ -39,6 +40,7 @@ describe('preferences storage', () => {
       themeMode: 'dark',
       preferredSources: ['books-com-tw', 'kingstone'],
       preferredBookTypes: ['physical', 'ebook'],
+      icloudSyncEnabled: false,
     };
     await AsyncStorage.setItem('bookscompare:preferences:v1', JSON.stringify(stored));
 
@@ -55,6 +57,7 @@ describe('preferences storage', () => {
         themeMode: 'light',
         preferredSources: ['books-com-tw', 'unknown-source'],
         preferredBookTypes: ['ebook', 'ebook'],
+        icloudSyncEnabled: 'yes',
       })
     );
 
@@ -65,6 +68,7 @@ describe('preferences storage', () => {
       themeMode: 'light',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 
@@ -78,6 +82,7 @@ describe('preferences storage', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 

--- a/apps/mobile/src/lib/preferences.ts
+++ b/apps/mobile/src/lib/preferences.ts
@@ -7,6 +7,7 @@ import { loadJsonValue, saveJsonValue } from './jsonStorage';
 import type { BookSourceId } from '@bookscompare/contracts';
 
 export const PREFERENCES_STORAGE_KEY = 'bookscompare:preferences:v1';
+export const PREFERENCES_UPDATED_AT_STORAGE_KEY = 'bookscompare:preferences-updated-at:v1';
 
 export type OpenLinksIn = 'app' | 'browser';
 export type ThemeMode = 'system' | 'light' | 'dark';
@@ -19,6 +20,8 @@ export interface Preferences {
   preferredBookTypes: BookTypePreference[];
   icloudSyncEnabled: boolean;
 }
+
+export type SyncablePreferences = Omit<Preferences, 'icloudSyncEnabled'>;
 
 type PreferenceKey = keyof Preferences;
 
@@ -51,6 +54,19 @@ let currentPreferences = defaultPreferences;
 let preferencesLoaded = false;
 const listeners = new Set<(preferences: Preferences) => void>();
 const loadedListeners = new Set<(loaded: boolean) => void>();
+
+export function toSyncablePreferences(preferences: Preferences): SyncablePreferences {
+  return {
+    openLinksIn: preferences.openLinksIn,
+    themeMode: preferences.themeMode,
+    preferredSources: preferences.preferredSources,
+    preferredBookTypes: preferences.preferredBookTypes,
+  };
+}
+
+function parseTimestamp(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
 
 function parsePreferences(value: unknown): Preferences {
   if (!value || typeof value !== 'object') {
@@ -108,8 +124,24 @@ export async function loadPreferences(): Promise<Preferences> {
 // render has the best chance of having the user's saved theme ready.
 void loadPreferences();
 
-async function savePreferences(preferences: Preferences): Promise<void> {
-  await saveJsonValue(PREFERENCES_STORAGE_KEY, preferences);
+export async function loadPreferencesUpdatedAt(): Promise<number> {
+  return loadJsonValue(PREFERENCES_UPDATED_AT_STORAGE_KEY, 0, parseTimestamp);
+}
+
+async function savePreferences(preferences: Preferences, updatedAt = Date.now()): Promise<void> {
+  await Promise.all([
+    saveJsonValue(PREFERENCES_STORAGE_KEY, preferences),
+    saveJsonValue(PREFERENCES_UPDATED_AT_STORAGE_KEY, updatedAt),
+  ]);
+}
+
+export async function replacePreferences(
+  preferences: Preferences,
+  updatedAt = Date.now()
+): Promise<Preferences> {
+  await savePreferences(preferences, updatedAt);
+  emit(preferences);
+  return preferences;
 }
 
 export async function updatePreference<Key extends PreferenceKey>(

--- a/apps/mobile/src/lib/preferences.ts
+++ b/apps/mobile/src/lib/preferences.ts
@@ -27,7 +27,7 @@ type PreferenceKey = keyof Preferences;
 
 const validSourceIds = new Set<string>(BOOK_SOURCES.map((s) => s.id));
 
-const defaultPreferences: Preferences = {
+export const DEFAULT_PREFERENCES: Preferences = {
   openLinksIn: 'app',
   themeMode: 'system',
   preferredSources: [],
@@ -50,7 +50,7 @@ const validators: {
   icloudSyncEnabled: (value): value is boolean => typeof value === 'boolean',
 };
 
-let currentPreferences = defaultPreferences;
+let currentPreferences = DEFAULT_PREFERENCES;
 let preferencesLoaded = false;
 const listeners = new Set<(preferences: Preferences) => void>();
 const loadedListeners = new Set<(loaded: boolean) => void>();
@@ -70,16 +70,16 @@ function parseTimestamp(value: unknown): number {
 
 function parsePreferences(value: unknown): Preferences {
   if (!value || typeof value !== 'object') {
-    return defaultPreferences;
+    return DEFAULT_PREFERENCES;
   }
 
   const record = value as Record<string, unknown>;
-  return (Object.keys(defaultPreferences) as PreferenceKey[]).reduce<Preferences>(
+  return (Object.keys(DEFAULT_PREFERENCES) as PreferenceKey[]).reduce<Preferences>(
     (preferences, key) => ({
       ...preferences,
-      [key]: validators[key](record[key]) ? record[key] : defaultPreferences[key],
+      [key]: validators[key](record[key]) ? record[key] : DEFAULT_PREFERENCES[key],
     }),
-    defaultPreferences
+    DEFAULT_PREFERENCES
   );
 }
 
@@ -107,7 +107,7 @@ export async function loadPreferences(): Promise<Preferences> {
     try {
       const preferences = await loadJsonValue(
         PREFERENCES_STORAGE_KEY,
-        defaultPreferences,
+        DEFAULT_PREFERENCES,
         parsePreferences
       );
       emit(preferences);

--- a/apps/mobile/src/lib/preferences.ts
+++ b/apps/mobile/src/lib/preferences.ts
@@ -17,6 +17,7 @@ export interface Preferences {
   themeMode: ThemeMode;
   preferredSources: BookSourceId[];
   preferredBookTypes: BookTypePreference[];
+  icloudSyncEnabled: boolean;
 }
 
 type PreferenceKey = keyof Preferences;
@@ -28,6 +29,7 @@ const defaultPreferences: Preferences = {
   themeMode: 'system',
   preferredSources: [],
   preferredBookTypes: [],
+  icloudSyncEnabled: true,
 };
 
 const validators: {
@@ -42,6 +44,7 @@ const validators: {
     Array.isArray(value) &&
     value.every((v) => v === 'physical' || v === 'ebook') &&
     new Set(value).size === value.length,
+  icloudSyncEnabled: (value): value is boolean => typeof value === 'boolean',
 };
 
 let currentPreferences = defaultPreferences;

--- a/apps/mobile/src/screens/about/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/about/AboutScreen.test.tsx
@@ -16,6 +16,7 @@ const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   themeMode: 'system',
   preferredSources: [],
   preferredBookTypes: [],
+  icloudSyncEnabled: true,
 }));
 
 jest.mock('../../lib/preferences', () => ({
@@ -32,6 +33,7 @@ describe('AboutScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 
@@ -61,6 +63,7 @@ describe('AboutScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
 
     const navigation = {

--- a/apps/mobile/src/screens/about/BookTypePreferencesScreen.test.tsx
+++ b/apps/mobile/src/screens/about/BookTypePreferencesScreen.test.tsx
@@ -16,6 +16,7 @@ const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   themeMode: 'system',
   preferredSources: [],
   preferredBookTypes: [],
+  icloudSyncEnabled: true,
 }));
 
 jest.mock('../../lib/preferences', () => ({
@@ -32,6 +33,7 @@ describe('BookTypePreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 
@@ -70,6 +72,7 @@ describe('BookTypePreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: ['physical', 'ebook'],
+      icloudSyncEnabled: true,
     });
 
     const screen = renderWithProviders(
@@ -94,6 +97,7 @@ describe('BookTypePreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: ['ebook'],
+      icloudSyncEnabled: true,
     });
 
     const screen = renderWithProviders(
@@ -113,6 +117,7 @@ describe('BookTypePreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: ['physical'],
+      icloudSyncEnabled: true,
     });
 
     const screen = renderWithProviders(

--- a/apps/mobile/src/screens/about/BookTypePreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/BookTypePreferencesScreen.tsx
@@ -28,7 +28,11 @@ export function BookTypePreferencesScreen(_props: Props) {
 
     track('settings_change', { key: 'preferredBookTypes', value: nextPreference.join(',') });
     void Promise.resolve(updatePreference('preferredBookTypes', nextPreference)).then(
-      syncPreferencesToIcloud
+      (updatedPreferences) => {
+        if (updatedPreferences) {
+          void syncPreferencesToIcloud(updatedPreferences);
+        }
+      }
     );
   };
 

--- a/apps/mobile/src/screens/about/BookTypePreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/BookTypePreferencesScreen.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { track } from '../../analytics';
 import { ToggleListScreen } from '../../components/PreferenceListScreen';
 import { strings } from '../../i18n/strings';
+import { syncPreferencesToIcloud } from '../../lib/icloudSync';
 import { updatePreference, usePreferences } from '../../lib/preferences';
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -26,7 +27,9 @@ export function BookTypePreferencesScreen(_props: Props) {
       : [...preferredBookTypes, nextValue];
 
     track('settings_change', { key: 'preferredBookTypes', value: nextPreference.join(',') });
-    void updatePreference('preferredBookTypes', nextPreference);
+    void Promise.resolve(updatePreference('preferredBookTypes', nextPreference)).then(
+      syncPreferencesToIcloud
+    );
   };
 
   return (

--- a/apps/mobile/src/screens/about/OpenLinksPreferencesScreen.test.tsx
+++ b/apps/mobile/src/screens/about/OpenLinksPreferencesScreen.test.tsx
@@ -16,6 +16,7 @@ const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   themeMode: 'system',
   preferredSources: [],
   preferredBookTypes: [],
+  icloudSyncEnabled: true,
 }));
 
 jest.mock('../../lib/preferences', () => ({
@@ -32,6 +33,7 @@ describe('OpenLinksPreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 
@@ -84,6 +86,7 @@ describe('OpenLinksPreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
 
     const screen = renderWithProviders(

--- a/apps/mobile/src/screens/about/OpenLinksPreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/OpenLinksPreferencesScreen.tsx
@@ -1,6 +1,7 @@
 import { track } from '../../analytics';
 import { SelectionListScreen } from '../../components/PreferenceListScreen';
 import { strings } from '../../i18n/strings';
+import { syncPreferencesToIcloud } from '../../lib/icloudSync';
 import { updatePreference, usePreferences } from '../../lib/preferences';
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -23,7 +24,7 @@ export function OpenLinksPreferencesScreen(_props: Props) {
     }
 
     track('settings_change', { key: 'openLinksIn', value });
-    void updatePreference('openLinksIn', value);
+    void Promise.resolve(updatePreference('openLinksIn', value)).then(syncPreferencesToIcloud);
   };
 
   return (

--- a/apps/mobile/src/screens/about/OpenLinksPreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/OpenLinksPreferencesScreen.tsx
@@ -24,7 +24,11 @@ export function OpenLinksPreferencesScreen(_props: Props) {
     }
 
     track('settings_change', { key: 'openLinksIn', value });
-    void Promise.resolve(updatePreference('openLinksIn', value)).then(syncPreferencesToIcloud);
+    void Promise.resolve(updatePreference('openLinksIn', value)).then((updatedPreferences) => {
+      if (updatedPreferences) {
+        void syncPreferencesToIcloud(updatedPreferences);
+      }
+    });
   };
 
   return (

--- a/apps/mobile/src/screens/about/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.test.tsx
@@ -1,28 +1,40 @@
 import { fireEvent } from '@testing-library/react-native';
 
-import { SettingsScreen } from './SettingsScreen';
+import { SettingsScreen, shouldShowIcloudSyncSetting } from './SettingsScreen';
 import { renderWithProviders } from '../../test/test-utils';
 
 import type { Preferences } from '../../lib/preferences';
+
+const mockUpdatePreference = jest.fn();
+const mockTrack = jest.fn();
 
 const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   openLinksIn: 'app',
   themeMode: 'system',
   preferredSources: [],
   preferredBookTypes: [],
+  icloudSyncEnabled: true,
 }));
 
 jest.mock('../../lib/preferences', () => ({
   usePreferences: () => mockGetPreferences(),
+  updatePreference: (...args: unknown[]) => mockUpdatePreference(...args),
+}));
+
+jest.mock('../../analytics', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
 }));
 
 describe('SettingsScreen', () => {
   beforeEach(() => {
+    mockTrack.mockClear();
+    mockUpdatePreference.mockClear();
     mockGetPreferences.mockReturnValue({
       openLinksIn: 'app',
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 
@@ -45,6 +57,7 @@ describe('SettingsScreen', () => {
       themeMode: 'dark',
       preferredSources: ['books-com-tw', 'eslite'],
       preferredBookTypes: ['ebook'],
+      icloudSyncEnabled: false,
     });
 
     const screen = renderWithProviders(
@@ -58,6 +71,7 @@ describe('SettingsScreen', () => {
     expect(screen.getByText('深色')).toBeOnTheScreen();
     expect(screen.getByText('電子書')).toBeOnTheScreen();
     expect(screen.getByText('已選 2 家')).toBeOnTheScreen();
+    expect(screen.getByText('關閉')).toBeOnTheScreen();
   });
 
   it('renders physical-books label when only physical books are preferred', () => {
@@ -66,6 +80,7 @@ describe('SettingsScreen', () => {
       themeMode: 'light',
       preferredSources: [],
       preferredBookTypes: ['physical'],
+      icloudSyncEnabled: true,
     });
 
     const screen = renderWithProviders(
@@ -137,5 +152,28 @@ describe('SettingsScreen', () => {
     fireEvent.press(screen.getByText(/跟隨系統/));
 
     expect(navigation.navigate).toHaveBeenCalledWith('ThemePreferences');
+  });
+
+  it('toggles iCloud sync from the iOS settings row', () => {
+    const screen = renderWithProviders(
+      <SettingsScreen
+        navigation={{} as never}
+        route={{ key: 'Settings', name: 'Settings' } as never}
+      />
+    );
+
+    fireEvent.press(screen.getByText('iCloud 同步'));
+
+    expect(mockTrack).toHaveBeenCalledWith('settings_change', {
+      key: 'icloudSyncEnabled',
+      value: 'false',
+    });
+    expect(mockUpdatePreference).toHaveBeenCalledWith('icloudSyncEnabled', false);
+  });
+
+  it('only shows the iCloud sync setting on iOS', () => {
+    expect(shouldShowIcloudSyncSetting('ios')).toBe(true);
+    expect(shouldShowIcloudSyncSetting('android')).toBe(false);
+    expect(shouldShowIcloudSyncSetting('web')).toBe(false);
   });
 });

--- a/apps/mobile/src/screens/about/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
 
 import { SettingsScreen, shouldShowIcloudSyncSetting } from './SettingsScreen';
 import { renderWithProviders } from '../../test/test-utils';
@@ -9,6 +10,8 @@ const mockUpdatePreference = jest.fn();
 const mockTrack = jest.fn();
 const mockSetQueryData = jest.fn();
 const mockRunInitialIcloudSync = jest.fn();
+const mockClearIcloudData = jest.fn();
+const mockResetAppData = jest.fn();
 
 const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   openLinksIn: 'app',
@@ -28,7 +31,12 @@ jest.mock('../../analytics', () => ({
 }));
 
 jest.mock('../../lib/icloudSync', () => ({
+  clearIcloudData: (...args: unknown[]) => mockClearIcloudData(...args),
   runInitialIcloudSync: (...args: unknown[]) => mockRunInitialIcloudSync(...args),
+}));
+
+jest.mock('../../lib/appData', () => ({
+  resetAppData: (...args: unknown[]) => mockResetAppData(...args),
 }));
 
 jest.mock('@tanstack/react-query', () => {
@@ -43,8 +51,13 @@ jest.mock('@tanstack/react-query', () => {
 });
 
 describe('SettingsScreen', () => {
+  const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+
   beforeEach(() => {
+    alertSpy.mockClear();
     mockTrack.mockClear();
+    mockClearIcloudData.mockClear();
+    mockResetAppData.mockClear();
     mockUpdatePreference.mockClear();
     mockSetQueryData.mockClear();
     mockRunInitialIcloudSync.mockClear();
@@ -54,6 +67,17 @@ describe('SettingsScreen', () => {
       preferredSources: [],
       preferredBookTypes: [],
       icloudSyncEnabled: true,
+    });
+    mockResetAppData.mockResolvedValue({
+      preferences: {
+        openLinksIn: 'app',
+        themeMode: 'system',
+        preferredSources: [],
+        preferredBookTypes: [],
+        icloudSyncEnabled: true,
+      },
+      history: [],
+      favourites: [],
     });
   });
 
@@ -226,5 +250,45 @@ describe('SettingsScreen', () => {
     expect(shouldShowIcloudSyncSetting('ios')).toBe(true);
     expect(shouldShowIcloudSyncSetting('android')).toBe(false);
     expect(shouldShowIcloudSyncSetting('web')).toBe(false);
+  });
+
+  it('shows a warning alert before resetting all data', () => {
+    const screen = renderWithProviders(
+      <SettingsScreen
+        navigation={{} as never}
+        route={{ key: 'Settings', name: 'Settings' } as never}
+      />
+    );
+
+    fireEvent.press(screen.getByText('重設所有資料'));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      '重設所有資料？',
+      '此動作無法復原，所有本機設定、搜尋記錄與收藏都會被移除，並同時清除 iCloud 上的同步資料。',
+      expect.any(Array)
+    );
+  });
+
+  it('resets local data and clears iCloud data after confirmation', async () => {
+    const screen = renderWithProviders(
+      <SettingsScreen
+        navigation={{} as never}
+        route={{ key: 'Settings', name: 'Settings' } as never}
+      />
+    );
+
+    fireEvent.press(screen.getByText('重設所有資料'));
+
+    const buttons = alertSpy.mock.calls[0]?.[2];
+    const confirmButton = buttons?.[1];
+    expect(confirmButton).toBeDefined();
+    confirmButton?.onPress?.();
+
+    await waitFor(() => {
+      expect(mockClearIcloudData).toHaveBeenCalledTimes(1);
+      expect(mockResetAppData).toHaveBeenCalledTimes(1);
+      expect(mockSetQueryData).toHaveBeenCalledWith(['history'], []);
+      expect(mockSetQueryData).toHaveBeenCalledWith(['favourites'], []);
+    });
   });
 });

--- a/apps/mobile/src/screens/about/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, waitFor } from '@testing-library/react-native';
 
 import { SettingsScreen, shouldShowIcloudSyncSetting } from './SettingsScreen';
 import { renderWithProviders } from '../../test/test-utils';
@@ -7,6 +7,8 @@ import type { Preferences } from '../../lib/preferences';
 
 const mockUpdatePreference = jest.fn();
 const mockTrack = jest.fn();
+const mockSetQueryData = jest.fn();
+const mockRunInitialIcloudSync = jest.fn();
 
 const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   openLinksIn: 'app',
@@ -25,10 +27,27 @@ jest.mock('../../analytics', () => ({
   track: (...args: unknown[]) => mockTrack(...args),
 }));
 
+jest.mock('../../lib/icloudSync', () => ({
+  runInitialIcloudSync: (...args: unknown[]) => mockRunInitialIcloudSync(...args),
+}));
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      setQueryData: (...args: unknown[]) => mockSetQueryData(...args),
+    }),
+  };
+});
+
 describe('SettingsScreen', () => {
   beforeEach(() => {
     mockTrack.mockClear();
     mockUpdatePreference.mockClear();
+    mockSetQueryData.mockClear();
+    mockRunInitialIcloudSync.mockClear();
     mockGetPreferences.mockReturnValue({
       openLinksIn: 'app',
       themeMode: 'system',
@@ -169,6 +188,38 @@ describe('SettingsScreen', () => {
       value: 'false',
     });
     expect(mockUpdatePreference).toHaveBeenCalledWith('icloudSyncEnabled', false);
+  });
+
+  it('applies empty synced history and favourites results', async () => {
+    mockGetPreferences.mockReturnValue({
+      openLinksIn: 'app',
+      themeMode: 'system',
+      preferredSources: [],
+      preferredBookTypes: [],
+      icloudSyncEnabled: false,
+    });
+    mockUpdatePreference.mockResolvedValue({
+      openLinksIn: 'app',
+      themeMode: 'system',
+      preferredSources: [],
+      preferredBookTypes: [],
+      icloudSyncEnabled: true,
+    });
+    mockRunInitialIcloudSync.mockResolvedValue({ history: [], favourites: [] });
+
+    const screen = renderWithProviders(
+      <SettingsScreen
+        navigation={{} as never}
+        route={{ key: 'Settings', name: 'Settings' } as never}
+      />
+    );
+
+    fireEvent.press(screen.getByText('iCloud 同步'));
+
+    await waitFor(() => {
+      expect(mockSetQueryData).toHaveBeenCalledWith(['history'], []);
+      expect(mockSetQueryData).toHaveBeenCalledWith(['favourites'], []);
+    });
   });
 
   it('only shows the iCloud sync setting on iOS', () => {

--- a/apps/mobile/src/screens/about/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.tsx
@@ -1,14 +1,15 @@
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { track } from '../../analytics';
 import { FAVOURITES_QUERY_KEY } from '../../api/favourites';
 import { HISTORY_QUERY_KEY } from '../../api/history';
 import { ListRow } from '../../components/ListRow';
 import { strings } from '../../i18n/strings';
-import { runInitialIcloudSync } from '../../lib/icloudSync';
+import { resetAppData } from '../../lib/appData';
+import { clearIcloudData, runInitialIcloudSync } from '../../lib/icloudSync';
 import { updatePreference, usePreferences } from '../../lib/preferences';
 import { spacing } from '../../theme/spacing';
 import { useTheme } from '../../theme/ThemeProvider';
@@ -95,6 +96,19 @@ export function SettingsScreen({ navigation }: Props) {
       ? strings.storePreferences.settingsRowValueAll
       : strings.storePreferences.settingsRowValue(preferences.preferredSources.length);
   const showIcloudSync = shouldShowIcloudSyncSetting();
+  const resetAllData = useMutation({
+    mutationFn: async () => {
+      if (preferences.icloudSyncEnabled) {
+        await clearIcloudData();
+      }
+
+      return resetAppData();
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData(HISTORY_QUERY_KEY, result.history);
+      queryClient.setQueryData(FAVOURITES_QUERY_KEY, result.favourites);
+    },
+  });
 
   const toggleIcloudSync = () => {
     const next = !preferences.icloudSyncEnabled;
@@ -113,6 +127,27 @@ export function SettingsScreen({ navigation }: Props) {
         }
       });
     });
+  };
+
+  const confirmResetAllData = () => {
+    track('settings_click_reset_all_data');
+    Alert.alert(
+      strings.settings.resetAllDataConfirmTitle,
+      preferences.icloudSyncEnabled
+        ? strings.settings.resetAllDataConfirmMessageWithIcloud
+        : strings.settings.resetAllDataConfirmMessage,
+      [
+        { text: strings.settings.cancelAction, style: 'cancel' },
+        {
+          text: strings.settings.resetAllDataConfirmAction,
+          style: 'destructive',
+          onPress: () => {
+            track('settings_reset_all_data_confirm');
+            resetAllData.mutate();
+          },
+        },
+      ]
+    );
   };
 
   return (
@@ -192,6 +227,20 @@ export function SettingsScreen({ navigation }: Props) {
           </View>
         </>
       ) : null}
+
+      <Text style={[styles.sectionHeader, styles.sectionHeaderSpaced]}>
+        {strings.settings.dataSection}
+      </Text>
+      <View style={styles.group}>
+        <ListRow
+          icon="trash-outline"
+          title={strings.settings.resetAllData}
+          onPress={confirmResetAllData}
+          destructive
+          hideChevron
+          isLast
+        />
+      </View>
     </ScrollView>
   );
 }

--- a/apps/mobile/src/screens/about/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.tsx
@@ -1,10 +1,14 @@
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { track } from '../../analytics';
+import { FAVOURITES_QUERY_KEY } from '../../api/favourites';
+import { HISTORY_QUERY_KEY } from '../../api/history';
 import { ListRow } from '../../components/ListRow';
 import { strings } from '../../i18n/strings';
+import { runInitialIcloudSync } from '../../lib/icloudSync';
 import { updatePreference, usePreferences } from '../../lib/preferences';
 import { spacing } from '../../theme/spacing';
 import { useTheme } from '../../theme/ThemeProvider';
@@ -82,6 +86,7 @@ function SettingsRow({
 export function SettingsScreen({ navigation }: Props) {
   const { colors } = useTheme();
   const preferences = usePreferences();
+  const queryClient = useQueryClient();
   const tabBarHeight = useBottomTabBarHeight();
   const styles = useMemo(() => createStyles(colors), [colors]);
 
@@ -94,7 +99,20 @@ export function SettingsScreen({ navigation }: Props) {
   const toggleIcloudSync = () => {
     const next = !preferences.icloudSyncEnabled;
     track('settings_change', { key: 'icloudSyncEnabled', value: String(next) });
-    void updatePreference('icloudSyncEnabled', next);
+    void Promise.resolve(updatePreference('icloudSyncEnabled', next)).then((updatedPreferences) => {
+      if (!updatedPreferences?.icloudSyncEnabled) {
+        return;
+      }
+
+      void runInitialIcloudSync().then((syncResult) => {
+        if (syncResult.history) {
+          queryClient.setQueryData(HISTORY_QUERY_KEY, syncResult.history);
+        }
+        if (syncResult.favourites) {
+          queryClient.setQueryData(FAVOURITES_QUERY_KEY, syncResult.favourites);
+        }
+      });
+    });
   };
 
   return (

--- a/apps/mobile/src/screens/about/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.tsx
@@ -105,10 +105,10 @@ export function SettingsScreen({ navigation }: Props) {
       }
 
       void runInitialIcloudSync().then((syncResult) => {
-        if (syncResult.history) {
+        if (syncResult.history !== undefined) {
           queryClient.setQueryData(HISTORY_QUERY_KEY, syncResult.history);
         }
-        if (syncResult.favourites) {
+        if (syncResult.favourites !== undefined) {
           queryClient.setQueryData(FAVOURITES_QUERY_KEY, syncResult.favourites);
         }
       });

--- a/apps/mobile/src/screens/about/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/about/SettingsScreen.tsx
@@ -1,10 +1,11 @@
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useMemo } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 
+import { track } from '../../analytics';
 import { ListRow } from '../../components/ListRow';
 import { strings } from '../../i18n/strings';
-import { usePreferences } from '../../lib/preferences';
+import { updatePreference, usePreferences } from '../../lib/preferences';
 import { spacing } from '../../theme/spacing';
 import { useTheme } from '../../theme/ThemeProvider';
 import { typography } from '../../theme/typography';
@@ -15,6 +16,10 @@ import type { ThemeColors } from '../../theme/colors';
 import type { AboutStackParamList } from '../../navigation/types';
 
 type Props = NativeStackScreenProps<AboutStackParamList, 'Settings'>;
+
+export function shouldShowIcloudSyncSetting(platformOS = Platform.OS): boolean {
+  return platformOS === 'ios';
+}
 
 function openLinksLabel(value: OpenLinksIn): string {
   return value === 'app' ? strings.settings.openLinksInApp : strings.settings.openLinksInBrowser;
@@ -48,6 +53,7 @@ interface SettingsRowProps {
   title: string;
   value: string;
   onPress: () => void;
+  hideChevron?: boolean;
   isLast?: boolean;
 }
 
@@ -57,6 +63,7 @@ function SettingsRow({
   title,
   value,
   onPress,
+  hideChevron = false,
   isLast = true,
 }: SettingsRowProps) {
   return (
@@ -66,6 +73,7 @@ function SettingsRow({
       title={title}
       value={value}
       onPress={onPress}
+      hideChevron={hideChevron}
       isLast={isLast}
     />
   );
@@ -81,6 +89,13 @@ export function SettingsScreen({ navigation }: Props) {
     preferences.preferredSources.length === 0
       ? strings.storePreferences.settingsRowValueAll
       : strings.storePreferences.settingsRowValue(preferences.preferredSources.length);
+  const showIcloudSync = shouldShowIcloudSyncSetting();
+
+  const toggleIcloudSync = () => {
+    const next = !preferences.icloudSyncEnabled;
+    track('settings_change', { key: 'icloudSyncEnabled', value: String(next) });
+    void updatePreference('icloudSyncEnabled', next);
+  };
 
   return (
     <ScrollView
@@ -136,6 +151,29 @@ export function SettingsScreen({ navigation }: Props) {
           isLast
         />
       </View>
+
+      {showIcloudSync ? (
+        <>
+          <Text style={[styles.sectionHeader, styles.sectionHeaderSpaced]}>
+            {strings.settings.syncSection}
+          </Text>
+          <View style={styles.group}>
+            <SettingsRow
+              icon="cloud-outline"
+              iconBackground={colors.accentDeep}
+              title={strings.settings.icloudSync}
+              value={
+                preferences.icloudSyncEnabled
+                  ? strings.settings.icloudSyncOn
+                  : strings.settings.icloudSyncOff
+              }
+              onPress={toggleIcloudSync}
+              hideChevron
+              isLast
+            />
+          </View>
+        </>
+      ) : null}
     </ScrollView>
   );
 }

--- a/apps/mobile/src/screens/about/StorePreferencesScreen.test.tsx
+++ b/apps/mobile/src/screens/about/StorePreferencesScreen.test.tsx
@@ -16,6 +16,7 @@ const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   themeMode: 'system',
   preferredSources: [],
   preferredBookTypes: [],
+  icloudSyncEnabled: true,
 }));
 
 jest.mock('../../lib/preferences', () => ({
@@ -32,6 +33,7 @@ describe('StorePreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 
@@ -84,6 +86,7 @@ describe('StorePreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: ['books-com-tw', 'eslite'],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
 
     const screen = renderWithProviders(
@@ -104,6 +107,7 @@ describe('StorePreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: ['kingstone'],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
 
     const screen = renderWithProviders(

--- a/apps/mobile/src/screens/about/StorePreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/StorePreferencesScreen.tsx
@@ -29,7 +29,11 @@ export function StorePreferencesScreen(_props: Props) {
       : [...preferredSources, sourceId];
 
     track('settings_change', { key: 'preferredSources', value: next.join(',') });
-    void Promise.resolve(updatePreference('preferredSources', next)).then(syncPreferencesToIcloud);
+    void Promise.resolve(updatePreference('preferredSources', next)).then((updatedPreferences) => {
+      if (updatedPreferences) {
+        void syncPreferencesToIcloud(updatedPreferences);
+      }
+    });
   };
 
   return (

--- a/apps/mobile/src/screens/about/StorePreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/StorePreferencesScreen.tsx
@@ -5,6 +5,7 @@ import { BOOK_SOURCES } from '@bookscompare/contracts';
 import { track } from '../../analytics';
 import { ToggleListScreen } from '../../components/PreferenceListScreen';
 import { strings } from '../../i18n/strings';
+import { syncPreferencesToIcloud } from '../../lib/icloudSync';
 import { updatePreference, usePreferences } from '../../lib/preferences';
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -28,7 +29,7 @@ export function StorePreferencesScreen(_props: Props) {
       : [...preferredSources, sourceId];
 
     track('settings_change', { key: 'preferredSources', value: next.join(',') });
-    void updatePreference('preferredSources', next);
+    void Promise.resolve(updatePreference('preferredSources', next)).then(syncPreferencesToIcloud);
   };
 
   return (

--- a/apps/mobile/src/screens/about/ThemePreferencesScreen.test.tsx
+++ b/apps/mobile/src/screens/about/ThemePreferencesScreen.test.tsx
@@ -16,6 +16,7 @@ const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   themeMode: 'system',
   preferredSources: [],
   preferredBookTypes: [],
+  icloudSyncEnabled: true,
 }));
 
 jest.mock('../../lib/preferences', () => ({
@@ -32,6 +33,7 @@ describe('ThemePreferencesScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
   });
 
@@ -85,6 +87,7 @@ describe('ThemePreferencesScreen', () => {
       themeMode: 'light',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
 
     const screen = renderWithProviders(

--- a/apps/mobile/src/screens/about/ThemePreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/ThemePreferencesScreen.tsx
@@ -1,6 +1,7 @@
 import { track } from '../../analytics';
 import { SelectionListScreen } from '../../components/PreferenceListScreen';
 import { strings } from '../../i18n/strings';
+import { syncPreferencesToIcloud } from '../../lib/icloudSync';
 import { updatePreference, usePreferences } from '../../lib/preferences';
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -24,7 +25,7 @@ export function ThemePreferencesScreen(_props: Props) {
     }
 
     track('settings_change', { key: 'themeMode', value });
-    void updatePreference('themeMode', value);
+    void Promise.resolve(updatePreference('themeMode', value)).then(syncPreferencesToIcloud);
   };
 
   return (

--- a/apps/mobile/src/screens/about/ThemePreferencesScreen.tsx
+++ b/apps/mobile/src/screens/about/ThemePreferencesScreen.tsx
@@ -25,7 +25,11 @@ export function ThemePreferencesScreen(_props: Props) {
     }
 
     track('settings_change', { key: 'themeMode', value });
-    void Promise.resolve(updatePreference('themeMode', value)).then(syncPreferencesToIcloud);
+    void Promise.resolve(updatePreference('themeMode', value)).then((updatedPreferences) => {
+      if (updatedPreferences) {
+        void syncPreferencesToIcloud(updatedPreferences);
+      }
+    });
   };
 
   return (

--- a/apps/mobile/src/screens/home/SearchResultScreen.test.tsx
+++ b/apps/mobile/src/screens/home/SearchResultScreen.test.tsx
@@ -23,6 +23,7 @@ const mockGetPreferences = jest.fn<Preferences, []>(() => ({
   themeMode: 'system',
   preferredSources: [],
   preferredBookTypes: [],
+  icloudSyncEnabled: true,
 }));
 
 jest.mock('../../analytics', () => ({
@@ -142,6 +143,7 @@ describe('SearchResultScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
     mockUseFavourites.mockReturnValue({ data: [], isLoading: false });
     mockUseIsFavourite.mockReturnValue(false);
@@ -359,6 +361,7 @@ describe('SearchResultScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: ['physical'],
+      icloudSyncEnabled: true,
     });
     mockUseTitleSearch.mockReturnValue({
       data: createTitleData([
@@ -435,6 +438,7 @@ describe('SearchResultScreen', () => {
       themeMode: 'system',
       preferredSources: ['eslite', 'books-com-tw'],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
     mockUseTitleSearch.mockReturnValue({
       data: createTitleData([
@@ -532,6 +536,7 @@ describe('SearchResultScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: ['ebook'],
+      icloudSyncEnabled: true,
     });
     mockUseTitleSearch.mockReturnValue({
       data: createTitleData([createOffer({ productType: '中文書' })]),
@@ -559,6 +564,7 @@ describe('SearchResultScreen', () => {
       themeMode: 'system',
       preferredSources: [],
       preferredBookTypes: [],
+      icloudSyncEnabled: true,
     });
     mockUseTitleSearch.mockReturnValue({
       data: createTitleData([createOffer({ url: 'https://example.com/browser-book' })]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
     },
     "apps/mobile": {
       "name": "@bookscompare/mobile",
-      "version": "2.8.2",
+      "version": "2.9.2",
       "dependencies": {
         "@bookscompare/contracts": "*",
         "@expo/react-native-action-sheet": "^4.1.1",
@@ -63,6 +63,7 @@
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
+        "expo-icloud-storage": "^0.1.1",
         "expo-localization": "^17.0.8",
         "expo-status-bar": "~3.0.9",
         "posthog-react-native": "^4.43.10",
@@ -5982,6 +5983,17 @@
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-icloud-storage": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/expo-icloud-storage/-/expo-icloud-storage-0.1.1.tgz",
+      "integrity": "sha512-yamcz3ane86qKVFZD5xefbw8zFZI/PFY2kQp5ZPiYSVtmWZTuFIoOTTcZDZQodTQfocyjFZWrEz6omrbY74qeg==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",


### PR DESCRIPTION
## Summary
- add iCloud sync support for mobile preferences, history, and favourites on iOS
- add a reset-all-data action that clears local state and removes synced iCloud data after confirmation
- harden startup and settings flows with sync merge fixes, cache updates, and a safe fallback when the native iCloud module is unavailable

## Changes
- add iCloud storage integration, merge logic, and startup sync wiring for preferences, history, and favourites
- add settings UI for iCloud sync and a destructive reset-all-data option with localized copy
- update history and favourites persistence flows to sync cleared and merged results back into React Query
- add regression tests for sync behavior, reset flows, and missing native-module handling support

🤖 Generated with [Claude Code](https://claude.com/claude-code)